### PR TITLE
Modular watchers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,6 @@ let package = Package(
     name: "Inotify",
     dependencies: [
         .Package(url: "https://github.com/Ponyboy47/Cinotify.git", majorVersion: 2),
-        .Package(url: "https://github.com/Ponyboy47/ErrNo.git", majorVersion: 0, minor: 1)
+        .Package(url: "https://github.com/Ponyboy47/ErrNo.git", majorVersion: 0, minor: 2)
     ]
 )

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Annoyed with the lack of FileSystemEvent notifications in Swift on Linux that ar
 ## Usage:
 Add this to your Package.swift:
 ```swift
-.Package(url: "https://github.com/Ponyboy47/inotify.git", majorVersion: 0, minor: 1)
+.Package(url: "https://github.com/Ponyboy47/inotify.git", majorVersion: 0, minor: 2)
 ```
 
-NOTE: The current version of Inotify (0.1.1) uses Swift 3.1.1
+NOTE: The current version of Inotify (0.2.0) uses Swift 3.1.1
 
 Use it like this:
 ```swift
@@ -49,21 +49,41 @@ do {
 
 More examples to come later...
 
+## Creating custom watchers:
+It is possible to write your own watcher that will block a thread until a file descriptor is ready for reading
+By default, I've provided one using the C select API's and I plan on adding more later. (See the Todo for the others I plan on adding and feel free to help me out by making them yourself and submitting a pull request)
+
+There are 2 Protocols to choose from to implement a watcher:
+- InotifyEventWatcher
+- InotifyStoppableEventWatcher
+
+The only difference, is that the Stoppable watcher can be force stopped while it is blocking a thread (ie: receive a signal to be interrupted and stop gracefully, like epoll)
+
+A watcher just needs to monitor the inotify file descriptor for when it is ready to be read from. Once the file descriptor can be read from, unblock the thread and the Inotify class object will handle the actual reading of the file descriptor and subsequent creating of the InotifyEvents and executing of the callbacks.
+
+You can look at polling+Select.swift to see how I implemented the select-based watcher.
+
 ## Known Issues:
 When using the select-based monitoring, calling `inotify.stop()` will not stop the inotify watcher until the next event is triggered
 
 ## Todo:
 - [x] Init with inotify_init1 for flags
 - [x] Useful errors with ErrNo
-- [x] Select based watcher
-- [x] Polling based watcher (untested)
-- [ ] Write tests for the polling based watcher
 - [x] Asynchronous monitoring
 - [ ] Synchronous monitoring
 - [ ] Better error propogation in the asynchronous monitors
 - [ ] Update to Swift 4
-- [ ] Add more watchers
+- [ ] Support various watcher implementations
+  - [ ] select
+  - [ ] manual polling
   - [ ] poll
   - [ ] epoll
   - [ ] pselect
-- [ ] Make watchers more modular (so that others could easily write their own custom ones)
+- [ ] Write tests for the watchers
+  - [x] select
+  - [ ] manual polling
+  - [ ] poll
+  - [ ] epoll
+  - [ ] pselect
+- [x] Make watchers more modular (so that others could easily write their own custom ones)
+- [x] Auto-stop the watcher if there are no more paths to watch (occurs when all paths were one-shot events and they've all been triggered already)

--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ When using the select-based monitoring, calling `inotify.stop()` will not stop t
   - [ ] poll
   - [ ] epoll
   - [ ] pselect
+- [ ] Make watchers more modular (so that others could easily write their own custom ones)

--- a/Sources/inotify+Errors.swift
+++ b/Sources/inotify+Errors.swift
@@ -71,29 +71,6 @@ public enum InotifyError: Error {
         case unknownUnwatchFailure(FilePath)
     }
 
-    public enum SelectError: Error {
-        /**
-            An invalid file descriptor was given in one of the sets. (Perhaps a file descriptor that was
-            already closed, or one on which an error has occurred.)
-        */
-        case invalidFileDescriptor
-        /// A signal was caught; see signal(7)
-        case caughtSignal
-        /**
-            Set size is negative or exceeds the RLIMIT_NOFILE resource limit (see getrlimit(2))
-        */
-        case badSetSizeLimit_OR_InvalidTimeout
-        /// Unable to allocate memory for internal tables
-        case noMemory
-        /// The select timeout ocurred before an event was triggered
-        case timeout
-        /**
-            Did not receive a valid filde descriptor and we were unable
-            to identify why using the errno
-        */
-        case unknownSelectFailure
-    }
-
     public enum EventError: Error {
         /// Unable to find a watcher in the array of watchers with a matching watch descriptor
         case noWatcherWithDescriptor(WatchDescriptor)

--- a/Sources/inotify+Errors.swift
+++ b/Sources/inotify+Errors.swift
@@ -74,5 +74,7 @@ public enum InotifyError: Error {
     public enum EventError: Error {
         /// Unable to find a watcher in the array of watchers with a matching watch descriptor
         case noWatcherWithDescriptor(WatchDescriptor)
+        /// There were a number of bytes leftover that did not meet the inotify_event struct's min size
+        case leftoverBytes(Int)
     }
 }

--- a/Sources/inotify+Errors.swift
+++ b/Sources/inotify+Errors.swift
@@ -71,6 +71,17 @@ public enum InotifyError: Error {
         case unknownUnwatchFailure(FilePath)
     }
 
+    public enum ReadError: Error {
+        case nonBlockingDescriptorWouldBeBlocked
+        case badFileDescriptor(FileDescriptor)
+        case bufferOutsideAccessibleAddressSpace
+        case signalInterupt
+        case unsuitableDescriptorForReading(FileDescriptor)
+        case IOError
+        case descriptorIsDirectory(FileDescriptor)
+        case unknownReadError
+    }
+
     public enum EventError: Error {
         /// Unable to find a watcher in the array of watchers with a matching watch descriptor
         case noWatcherWithDescriptor(WatchDescriptor)

--- a/Sources/inotify.swift
+++ b/Sources/inotify.swift
@@ -1,6 +1,5 @@
 import Cinotify
 import ErrNo
-import CSelect
 import Glibc
 import Dispatch
 import Foundation
@@ -21,11 +20,13 @@ public class Inotify {
     /// An array of Watcher structs for each path being watched
     private var watchers: [Watcher] = []
     /// True when monitoring, false when not
-    private var canMonitor = false
+    private var shouldMonitor = false
     /// The queue used for asyncing the select calls in the monitor loop
-    private let selectQueue: DispatchQueue = DispatchQueue(label: "inotify.select.queue", qos: .background, attributes: [.concurrent])
+    private let pollQueue: DispatchQueue = DispatchQueue(label: "inotify.poll.queue", qos: .background, attributes: [.concurrent])
     /// The queue used for the event callbacks
     private let callbackQueue: DispatchQueue
+    // The polling API to use for waiting for inotify events
+    private var eventWatcher: InotifyEventWatcher
 
     /// A struct for inotify watched paths
     private struct Watcher {
@@ -36,7 +37,7 @@ public class Inotify {
         /// The event mask that inotify is watching for
         fileprivate let mask: FileSystemEventType
         /// The callback to use when an event gets triggered
-        fileprivate let callback: (InotifyEvent) -> ()
+        fileprivate let callback: InotifyEventAction
         /**
             Whether or not the event is a oneShot event and should be removed
             from the watcher array after being used once
@@ -55,18 +56,20 @@ public class Inotify {
     /**
         Default initializer. Simply calls inotify_init1(flags = 0)
 
+        - Parameter eventWatcher: The polling API to use for watching for inotify events
         - Parameter qos: The quality of service to use for the event callbacks
 
         - Throws: When the file descriptor returned by inotify_init1(flags) is less than 0
     */
-    public convenience init(qos: DispatchQoS = .default) throws {
-        try self.init(flag: .none, qos: qos)
+    public convenience init(eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default) throws {
+        try self.init(flag: .none, eventWatcher: eventWatcher, qos: qos)
     }
 
     /**
         Initialize and watch for the specified events on all the paths
 
         - Parameters:
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - paths: An array of paths to watch
             - events: An array of the events for which to monitor on each of the paths
@@ -75,8 +78,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(qos: DispatchQoS = .default, watching paths: [FilePath], for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(qos: qos)
+    public convenience init(eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching paths: [FilePath], for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(eventWatcher: eventWatcher, qos: qos)
         try self.watch(paths: paths, for: events, actionOnEvent: callback)
     }
 
@@ -84,6 +87,7 @@ public class Inotify {
         Initialize and watch for the specified events on all the paths
 
         - Parameters:
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - paths: An array of paths to watch
             - event: A single event for which to monitor on each of the paths
@@ -92,14 +96,15 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(qos: DispatchQoS = .default, watching paths: [FilePath], for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(qos: qos, watching: paths, for: [event], actionOnEvent: callback)
+    public convenience init(eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching paths: [FilePath], for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(eventWatcher: eventWatcher, qos: qos, watching: paths, for: [event], actionOnEvent: callback)
     }
 
     /**
         Initialize and watch for the specified events on all the paths
 
         - Parameters:
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - path: The path to watch
             - events: An array of the events for which to monitor on the path
@@ -108,14 +113,15 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(qos: DispatchQoS = .default, watching path: FilePath, for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(qos: qos, watching: [path], for: events, actionOnEvent: callback)
+    public convenience init(eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching path: FilePath, for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(eventWatcher: eventWatcher, qos: qos, watching: [path], for: events, actionOnEvent: callback)
     }
 
     /**
         Initialize and watch for the specified events on all the paths
 
         - Parameters:
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - path: The path to watch
             - event: A single event for which to monitor on the path
@@ -124,8 +130,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(qos: DispatchQoS = .default, watching path: FilePath, for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(qos: qos, watching: [path], for: [event], actionOnEvent: callback)
+    public convenience init(eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching path: FilePath, for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(eventWatcher: eventWatcher, qos: qos, watching: [path], for: [event], actionOnEvent: callback)
     }
 
     /**
@@ -133,11 +139,12 @@ public class Inotify {
 
         - Parameters:
             - flags: An array of flags to pass to inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
 
         - Throws: When the file descriptor returned by inotify_init1() is less than 0
     */
-    public init(flags: [InotifyFlag], qos: DispatchQoS = .default) throws {
+    public init(flags: [InotifyFlag], eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default) throws {
         var initFlags: InotifyFlagType = 0
         for flag in flags {
             initFlags |= flag.rawValue
@@ -161,6 +168,8 @@ public class Inotify {
             throw InotifyError.InitError.unknownInitFailure
         }
         callbackQueue = DispatchQueue(label: "inotify.callback.queue", qos: qos, attributes: [.concurrent])
+        self.eventWatcher = eventWatcher ?? SelectEventWatcher()
+        self.eventWatcher.fileDescriptor = fileDescriptor
     }
 
     /**
@@ -168,12 +177,13 @@ public class Inotify {
 
         - Parameters:
             - flag: A single flag to pass to inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
 
         - Throws: When the file descriptor returned by inotify_init1() is less than 0
     */
-    public convenience init(flag: InotifyFlag, qos: DispatchQoS = .default) throws {
-        try self.init(flags: [flag], qos: qos)
+    public convenience init(flag: InotifyFlag, eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default) throws {
+        try self.init(flags: [flag], eventWatcher: eventWatcher, qos: qos)
     }
 
     /**
@@ -181,6 +191,7 @@ public class Inotify {
 
         - Parameters:
             - flags: The inotify flags to use in inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - paths: An array of paths to watch
             - events: An array of the events for which to monitor on each of the paths
@@ -189,8 +200,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(flags: [InotifyFlag], qos: DispatchQoS = .default, watching paths: [FilePath], for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(flags: flags, qos: qos)
+    public convenience init(flags: [InotifyFlag], eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching paths: [FilePath], for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(flags: flags, eventWatcher: eventWatcher, qos: qos)
         try self.watch(paths: paths, for: events, actionOnEvent: callback)
     }
 
@@ -199,6 +210,7 @@ public class Inotify {
 
         - Parameters:
             - flags: The inotify flags to use in inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - paths: An array of paths to watch
             - event: A single event for which to monitor on each of the paths
@@ -207,8 +219,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(flags: [InotifyFlag], qos: DispatchQoS = .default, watching paths: [FilePath], for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(flags: flags, qos: qos, watching: paths, for: [event], actionOnEvent: callback)
+    public convenience init(flags: [InotifyFlag], eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching paths: [FilePath], for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(flags: flags, eventWatcher: eventWatcher, qos: qos, watching: paths, for: [event], actionOnEvent: callback)
     }
 
     /**
@@ -216,6 +228,7 @@ public class Inotify {
 
         - Parameters:
             - flags: The inotify flags to use in inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - path: The path to watch
             - events: An array of the events for which to monitor on the path
@@ -224,8 +237,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(flags: [InotifyFlag], qos: DispatchQoS = .default, watching path: FilePath, for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(flags: flags, qos: qos, watching: [path], for: events, actionOnEvent: callback)
+    public convenience init(flags: [InotifyFlag], eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching path: FilePath, for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(flags: flags, eventWatcher: eventWatcher, qos: qos, watching: [path], for: events, actionOnEvent: callback)
     }
 
     /**
@@ -233,6 +246,7 @@ public class Inotify {
 
         - Parameters:
             - flags: The inotify flags to use in inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - path: The path to watch
             - event: A single event for which to monitor on the path
@@ -241,8 +255,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(flags: [InotifyFlag], qos: DispatchQoS = .default, watching path: FilePath, for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(flags: flags, qos: qos, watching: [path], for: [event], actionOnEvent: callback)
+    public convenience init(flags: [InotifyFlag], eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching path: FilePath, for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(flags: flags, eventWatcher: eventWatcher, qos: qos, watching: [path], for: [event], actionOnEvent: callback)
     }
 
     /**
@@ -250,6 +264,7 @@ public class Inotify {
 
         - Parameters:
             - flag: The inotify flag to use in inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - paths: An array of paths to watch
             - events: An array of the events for which to monitor on each of the paths
@@ -258,8 +273,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(flag: InotifyFlag, qos: DispatchQoS = .default, watching paths: [FilePath], for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(flags: [flag], qos: qos, watching: paths, for: events, actionOnEvent: callback)
+    public convenience init(flag: InotifyFlag, eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching paths: [FilePath], for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(flags: [flag], eventWatcher: eventWatcher, qos: qos, watching: paths, for: events, actionOnEvent: callback)
     }
 
     /**
@@ -267,6 +282,7 @@ public class Inotify {
 
         - Parameters:
             - flag: The inotify flag to use in inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - paths: An array of paths to watch
             - event: A single event for which to monitor on each of the paths
@@ -275,8 +291,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(flag: InotifyFlag, qos: DispatchQoS = .default, watching paths: [FilePath], for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(flags: [flag], qos: qos, watching: paths, for: [event], actionOnEvent: callback)
+    public convenience init(flag: InotifyFlag, eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching paths: [FilePath], for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(flags: [flag], eventWatcher: eventWatcher, qos: qos, watching: paths, for: [event], actionOnEvent: callback)
     }
 
     /**
@@ -284,6 +300,7 @@ public class Inotify {
 
         - Parameters:
             - flag: The inotify flag to use in inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - path: The path to watch
             - events: An array of the events for which to monitor on the path
@@ -292,8 +309,8 @@ public class Inotify {
         - Throws: If the inotify_init() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(flag: InotifyFlag, qos: DispatchQoS = .default, watching path: FilePath, for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(flags: [flag], qos: qos, watching: [path], for: events, actionOnEvent: callback)
+    public convenience init(flag: InotifyFlag, eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching path: FilePath, for events: [FileSystemEvent], actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(flags: [flag], eventWatcher: eventWatcher, qos: qos, watching: [path], for: events, actionOnEvent: callback)
     }
 
     /**
@@ -301,6 +318,7 @@ public class Inotify {
 
         - Parameters:
             - flag: The inotify flag to use in inotify_init1(flags)
+            - eventWatcher: The polling API to use for watching for inotify events
             - qos: The quality of service to use for the event callbacks
             - path: The path to watch
             - event: A single event for which to monitor on the path
@@ -309,8 +327,8 @@ public class Inotify {
         - Throws: If the inotify_init1() file descriptor is less than 0
         - Throws: If the inotify_add_watch(fd, path, mask) returned a file descriptor less than 0 for one of the paths
     */
-    public convenience init(flag: InotifyFlag, qos: DispatchQoS = .default, watching path: FilePath, for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
-        try self.init(flags: [flag], qos: qos, watching: [path], for: [event], actionOnEvent: callback)
+    public convenience init(flag: InotifyFlag, eventWatcher: InotifyEventWatcher? = nil, qos: DispatchQoS = .default, watching path: FilePath, for event: FileSystemEvent, actionOnEvent callback: @escaping InotifyEventAction) throws {
+        try self.init(flags: [flag], eventWatcher: eventWatcher, qos: qos, watching: [path], for: [event], actionOnEvent: callback)
     }
 
     /**
@@ -458,14 +476,30 @@ public class Inotify {
         }
     }
 
-    public func start(actionQueue queue: DispatchQueue? = nil, useSelect: Bool = true, timeout: timeval? = nil) {
-        let queue = queue ?? self.callbackQueue
-        self.selectQueue.async {
+    public func start() {
+        self.shouldMonitor = true
+        self.pollQueue.async {
             do {
-                if useSelect {
-                    try self.selectMonitor(actionQueue: queue, timeout: timeout)
-                } else {
-                    try self.manualMonitor(actionQueue: queue, readDelay: timeout)
+                while self.shouldMonitor {
+                    let events: [InotifyEvent] = try self.eventWatcher.watch()
+                    for event in events {
+                        guard let watcherIndex = self.watchers.index(where: { (watcher) in
+                            return watcher.descriptor == event.wd && watcher.mask == event.mask
+                        }) else {
+                            throw InotifyError.EventError.noWatcherWithDescriptor(event.wd)
+                        }
+                        let watcher = self.watchers[watcherIndex]
+
+                        self.callbackQueue.async {
+                            watcher.callback(event)
+                        }
+                        if watcher.oneShot {
+                            self.watchers.remove(at: watcherIndex)
+                            guard self.watchers.count > 0 else {
+                                break
+                            }
+                        }
+                    }
                 }
             } catch {
                 print("An error occurred while waiting for inotify events: \(error)")
@@ -473,104 +507,8 @@ public class Inotify {
         }
     }
 
-    /**
-        Begins monitoring for events using select to effectively wait until an event is triggered
-    */
-    private func selectMonitor(actionQueue queue: DispatchQueue, timeout: timeval? = nil) throws {
-        self.canMonitor = true
-
-        var fileDescriptorSet: fd_set = fd_set()
-        let carryoverBuffer: UnsafeMutablePointer<CChar> = UnsafeMutablePointer<CChar>.allocate(capacity: InotifyEvent.maxSize)
-        var carryoverBytes: Int = 0
-        var bytesRead: Int = 0
-        var buffer = UnsafeMutablePointer<CChar>.allocate(capacity: InotifyEvent.maxSize)
-
-        while self.canMonitor {
-            fd_zero(&fileDescriptorSet)
-            fd_setter(self.fileDescriptor, &fileDescriptorSet)
-
-            let count: Int32
-            if var t = timeout {
-                count = select(FD_SETSIZE, &fileDescriptorSet, nil, nil, &t)
-            } else {
-                count = select(FD_SETSIZE, &fileDescriptorSet, nil, nil, nil)
-            }
-
-            guard count > 0 else {
-                self.canMonitor = false
-
-                if count == 0 {
-                    throw InotifyError.SelectError.timeout
-                } else if let error = lastError() {
-                    switch error {
-                    case .EBADF:
-                        throw InotifyError.SelectError.invalidFileDescriptor
-                    case .EINTR:
-                        throw InotifyError.SelectError.caughtSignal
-                    case .EINVAL:
-                        throw InotifyError.SelectError.badSetSizeLimit_OR_InvalidTimeout
-                    case .ENOMEM:
-                        throw InotifyError.SelectError.noMemory
-                    default:
-                        throw InotifyError.SelectError.unknownSelectFailure
-                    }
-                }
-                throw InotifyError.SelectError.unknownSelectFailure
-            }
-
-            // Keep reading from the inotify file descriptor until there's nothing left to read
-            repeat {
-                if carryoverBytes > 0 {
-                    buffer.assign(from: carryoverBuffer, count: carryoverBytes)
-                    buffer = buffer.advanced(by: carryoverBytes)
-                }
-
-                // I have no idea what's going on, but reading the inotify
-                // event data into the buffer totally screws up the
-                // carryoverBytes variable. Setting the oldBytes variable and
-                // then re-assigning to carryoverBytes after the read seems to
-                // fix this...
-                let oldBytes = carryoverBytes
-                bytesRead = read(self.fileDescriptor, buffer, InotifyEvent.maxSize)
-                carryoverBytes = oldBytes
-                buffer = buffer.advanced(by: -carryoverBytes)
-
-                // Ensure the bytes read is large enough to cast to an
-                // inotify_event, or just skip this event in the buffer
-                guard bytesRead + carryoverBytes >= InotifyEvent.minSize else {
-                    continue
-                }
-
-                let event = InotifyEvent(from: buffer)
-                guard let watcherIndex = self.watchers.index(where: { (watcher) in
-                    return watcher.descriptor == event.wd && watcher.mask == event.mask
-                }) else {
-                    throw InotifyError.EventError.noWatcherWithDescriptor(event.wd)
-                }
-
-                let watcher = self.watchers[watcherIndex]
-
-                queue.async {
-                    watcher.callback(event)
-                }
-                if watcher.oneShot {
-                    self.watchers.remove(at: watcherIndex)
-                }
-
-                let bytesUsed = InotifyEvent.minSize + Int(event.len)
-                if bytesRead + carryoverBytes > bytesUsed {
-                    carryoverBytes = bytesRead + carryoverBytes - bytesUsed
-                    carryoverBuffer.assign(from: buffer.advanced(by: bytesUsed), count: carryoverBytes)
-                    buffer = buffer.advanced(by: -bytesUsed)
-                }
-            } while (bytesRead > 0)
-        }
-        buffer.deallocate(capacity: InotifyEvent.maxSize)
-        carryoverBuffer.deallocate(capacity: InotifyEvent.maxSize)
-    }
-
     private func manualMonitor(actionQueue queue: DispatchQueue, readDelay delay_timeval: timeval? = nil) throws {
-        self.canMonitor = true
+        self.shouldMonitor = true
         let delay: Double
         if let d = delay_timeval {
             delay = Double(d.tv_sec) + (Double(d.tv_usec) / 1000000.00)
@@ -583,7 +521,7 @@ public class Inotify {
         var carryoverBytes: Int = 0
         var bytesRead: Int = 0
         var buffer = UnsafeMutablePointer<CChar>.allocate(capacity: InotifyEvent.maxSize)
-        while self.canMonitor {
+        while self.shouldMonitor {
             repeat {
                 if carryoverBytes > 0 {
                     buffer.assign(from: carryoverBuffer, count: carryoverBytes)
@@ -640,7 +578,9 @@ public class Inotify {
     }
 
     public func stop() {
-        self.canMonitor = false
+        self.shouldMonitor = false
+        // If the event watcher can be stopped, then force stop it
+        (self.eventWatcher as? InotifyStoppableEventWatcher)?.stop()
     }
 
     deinit {

--- a/Sources/inotify_event.swift
+++ b/Sources/inotify_event.swift
@@ -19,6 +19,9 @@ public struct InotifyEvent {
     public let cookie: InotifyCookieType
     public let len: UInt32
     public var name: String? = nil
+    public lazy var size: Int = {
+        return InotifyEvent.minSize + Int(self.len)
+    }()
 
     static public let minSize = MemoryLayout<inotify_event>.size
     static public let maxSize = MemoryLayout<inotify_event>.size + Int(NAME_MAX) + 1

--- a/Sources/polling+Protocol.swift
+++ b/Sources/polling+Protocol.swift
@@ -1,0 +1,13 @@
+/// A protocol that can handle watching for Inotify events
+public protocol InotifyEventWatcher: class {
+    /// The inotify file descriptor where events will be read from
+    var fileDescriptor: FileDescriptor? { get set }
+    /// The function used to watch for inotify events
+    func watch() throws -> [InotifyEvent]
+}
+
+/// A specialiced InotifyWatcher that can be stopped while actively watching for Inotify events
+public protocol InotifyStoppableEventWatcher: InotifyEventWatcher {
+    /// The function that is called to stop the watcher
+    func stop()
+}

--- a/Sources/polling+Protocol.swift
+++ b/Sources/polling+Protocol.swift
@@ -3,7 +3,7 @@ public protocol InotifyEventWatcher: class {
     /// The inotify file descriptor where events will be read from
     var fileDescriptor: FileDescriptor? { get set }
     /// The function used to watch for inotify events
-    func watch() throws -> [InotifyEvent]
+    func wait() throws
 }
 
 /// A specialiced InotifyWatcher that can be stopped while actively watching for Inotify events

--- a/Sources/polling+Select.swift
+++ b/Sources/polling+Select.swift
@@ -1,0 +1,113 @@
+import CSelect
+import ErrNo
+
+public class SelectEventWatcher: InotifyEventWatcher {
+    public var fileDescriptor: FileDescriptor? = nil
+    let timeout: timeval?
+
+    init(_ timeout: timeval? = nil) {
+        self.timeout = timeout
+    }
+
+    public func watch() throws -> [InotifyEvent] {
+        guard let fd = fileDescriptor else {
+            throw SelectError.noFileDescriptor
+        }
+        var fileDescriptorSet: fd_set = fd_set()
+        let carryoverBuffer: UnsafeMutablePointer<CChar> = UnsafeMutablePointer<CChar>.allocate(capacity: InotifyEvent.maxSize)
+        var carryoverBytes: Int = 0
+        var bytesRead: Int = 0
+        var buffer: UnsafeMutablePointer<CChar> = UnsafeMutablePointer<CChar>.allocate(capacity: InotifyEvent.maxSize)
+
+        fd_zero(&fileDescriptorSet)
+        fd_setter(fd, &fileDescriptorSet)
+
+        var events: [InotifyEvent] = []
+
+        let count: Int32
+        if var t = timeout {
+            count = select(FD_SETSIZE, &fileDescriptorSet, nil, nil, &t)
+        } else {
+            count = select(FD_SETSIZE, &fileDescriptorSet, nil, nil, nil)
+        }
+
+        guard count > 0 else {
+            self.stop()
+
+            if count == 0 {
+                throw SelectError.timeout
+            } else if let error = lastError() {
+                switch error {
+                case .EBADF:
+                    throw SelectError.invalidFileDescriptor
+                case .EINTR:
+                    throw SelectError.caughtSignal
+                case .EINVAL:
+                    throw SelectError.badSetSizeLimit_OR_InvalidTimeout
+                case .ENOMEM:
+                    throw SelectError.noMemory
+                default:
+                    throw SelectError.unknownSelectFailure
+                }
+            }
+            throw SelectError.unknownSelectFailure
+        }
+
+
+        repeat {
+            if carryoverBytes > 0 {
+                buffer.assign(from: carryoverBuffer, count: carryoverBytes)
+                buffer = buffer.advanced(by: carryoverBytes)
+            }
+
+            let oldBytes = carryoverBytes
+            bytesRead = read(fd, buffer, InotifyEvent.maxSize)
+            carryoverBytes = oldBytes
+            buffer = buffer.advanced(by: -carryoverBytes)
+
+            guard bytesRead + carryoverBytes >= InotifyEvent.minSize else {
+                continue
+            }
+
+            let event = InotifyEvent(from: buffer)
+
+            events.append(event)
+
+            let bytesUsed = InotifyEvent.minSize + Int(event.len)
+            if bytesRead + carryoverBytes > bytesUsed {
+                carryoverBytes = bytesRead + carryoverBytes - bytesUsed
+                carryoverBuffer.assign(from: buffer.advanced(by: bytesUsed), count: carryoverBytes)
+                buffer = buffer.advanced(by: -bytesUsed)
+            }
+        } while (bytesRead > 0)
+        return events
+    }
+
+    public func stop() {
+    }
+}
+
+public enum SelectError: Error {
+    /**
+        An invalid file descriptor was given in one of the sets. (Perhaps a file descriptor that was
+        already closed, or one on which an error has occurred.)
+    */
+    case invalidFileDescriptor
+    /// A signal was caught; see signal(7)
+    case caughtSignal
+    /**
+        Set size is negative or exceeds the RLIMIT_NOFILE resource limit (see getrlimit(2))
+    */
+    case badSetSizeLimit_OR_InvalidTimeout
+    /// Unable to allocate memory for internal tables
+    case noMemory
+    /// The select timeout ocurred before an event was triggered
+    case timeout
+    /// The file descriptor for inotify has not been assigned yet
+    case noFileDescriptor
+    /**
+        Did not receive a valid filde descriptor and we were unable
+        to identify why using the errno
+    */
+    case unknownSelectFailure
+}

--- a/Sources/polling+Select.swift
+++ b/Sources/polling+Select.swift
@@ -13,12 +13,8 @@ public class SelectEventWatcher: InotifyEventWatcher {
         guard let fd = fileDescriptor else {
             throw SelectError.noFileDescriptor
         }
-        var fileDescriptorSet: fd_set = fd_set()
-        let carryoverBuffer: UnsafeMutablePointer<CChar> = UnsafeMutablePointer<CChar>.allocate(capacity: InotifyEvent.maxSize)
-        var carryoverBytes: Int = 0
-        var bytesRead: Int = 0
-        var buffer: UnsafeMutablePointer<CChar> = UnsafeMutablePointer<CChar>.allocate(capacity: InotifyEvent.maxSize)
 
+        var fileDescriptorSet: fd_set = fd_set()
         fd_zero(&fileDescriptorSet)
         fd_setter(fd, &fileDescriptorSet)
 

--- a/Sources/polling+Select.swift
+++ b/Sources/polling+Select.swift
@@ -22,8 +22,6 @@ public class SelectEventWatcher: InotifyEventWatcher {
         fd_zero(&fileDescriptorSet)
         fd_setter(fd, &fileDescriptorSet)
 
-        var events: [InotifyEvent] = []
-
         let count: Int32
         if var t = timeout {
             count = select(FD_SETSIZE, &fileDescriptorSet, nil, nil, &t)
@@ -36,13 +34,13 @@ public class SelectEventWatcher: InotifyEventWatcher {
                 throw SelectError.timeout
             } else if let error = lastError() {
                 switch error {
-                case .EBADF:
+                case EBADF:
                     throw SelectError.invalidFileDescriptor
-                case .EINTR:
+                case EINTR:
                     throw SelectError.caughtSignal
-                case .EINVAL:
+                case EINVAL:
                     throw SelectError.badSetSizeLimit_OR_InvalidTimeout
-                case .ENOMEM:
+                case ENOMEM:
                     throw SelectError.noMemory
                 default:
                     throw SelectError.unknownSelectFailure

--- a/Tests/InotifyTests/InotifyTests.swift
+++ b/Tests/InotifyTests/InotifyTests.swift
@@ -89,7 +89,6 @@ class InotifyTests: XCTestCase {
 
         inotify.start()
 
-        inotify.stop()
         self.createTestFile()
 
         waitForExpectations(timeout: 0.5, handler: nil)
@@ -132,7 +131,7 @@ class InotifyTests: XCTestCase {
 
         remove(self.createTestFile()!)
 
-        waitForExpectations(timeout: 5, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
         cleanupDirectoryForTest()
     }
 

--- a/Tests/InotifyTests/InotifyTests.swift
+++ b/Tests/InotifyTests/InotifyTests.swift
@@ -172,7 +172,7 @@ class InotifyTests: XCTestCase {
 
         inotify.stop()
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
         XCTAssertFalse(createdEvent)
         cleanupDirectoryForTest()
     }
@@ -205,7 +205,7 @@ class InotifyTests: XCTestCase {
 
         inotify.stop()
 
-        waitForExpectations(timeout: 1, handler: nil)
+        waitForExpectations(timeout: 0.5, handler: nil)
         cleanupDirectoryForTest()
     }
 


### PR DESCRIPTION
Created protocols for event watchers so that new ones can easily be created/used
Migrated the select-based watcher to the new modular system and made it the default
Fixed a number of bugs in the code that read the inotify file descriptor and processed it into inotify events
Updated the Readme